### PR TITLE
Tweak README for formatting issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,62 +6,62 @@
   Placebo is just a pretty wrapper around the features of meck.
 
   To enable just use Placebo in your ExUnit tests
-  ```
-    defmodule SomeTests do
-      use ExUnit.Case
-      use Placebo
+  ```elixir
+  defmodule SomeTests do
+    use ExUnit.Case
+    use Placebo
 
-      ## some awesome tests
+    ## some awesome tests
 
-    end
+  end
   ```
 
 
   ## Stubbing
 
-  ```
-    allow Some.Module.hello("world"), return: "some value"
+  ```elixir
+  allow Some.Module.hello("world"), return: "some value"
 
-    or
+  # or
 
-    allow(Some.Module.hello("world")) |> return("some value")
+  allow(Some.Module.hello("world")) |> return("some value")
   ```
   This will mock the module "Some.Module" and stub out the hello function with an argument of "world" to return "some value" when called.
   Any Elixir term can be returned using this syntax.
 
   If you want more dyanmic behavior you can have a function executed when the mock is called.
-  ```
-    allow Some.Module.hello(any()), exec: &String.upcase/1
-    allow Some.Module.hello(any()), exec: fn arg -> String.upcase(arg) end
+  ```elixir
+  allow Some.Module.hello(any()), exec: &String.upcase/1
+  allow Some.Module.hello(any()), exec: fn arg -> String.upcase(arg) end
 
-    or
+  # or
 
-    allow(Some.Module.hello(any())) |> exec(&String.upcase/1)
-    allow(Some.Module.hello(any())) |> exec(fn arg -> String.upcase(arg) end)
+  allow(Some.Module.hello(any())) |> exec(&String.upcase/1)
+  allow(Some.Module.hello(any())) |> exec(fn arg -> String.upcase(arg) end)
   ```
 
   If you pass no arguments in the allow section the arguments to the anonymous function will be used for matching.
-  ```
-    allow Some.Module.hello, exec: fn 1 -> "One"
-                                        2 -> "Two"
-                                        _ -> "Everything else" end
+  ```elixir
+  allow Some.Module.hello, exec: fn 1 -> "One"
+                                      2 -> "Two"
+                                      _ -> "Everything else" end
 
-    or
+  # or
 
-    allow(Some.Module.hello) |> exec(fn 1 -> "One"
-                                        2 -> "Two"
-                                        _ -> "Everything else" end)
+  allow(Some.Module.hello) |> exec(fn 1 -> "One"
+                                      2 -> "Two"
+                                      _ -> "Everything else" end)
   ```
 
   To return different values on subsequent calls use seq or loop
-  ```
-    allow Some.Module.hello(any()), seq: [1,2,3,4]
-    allow Some.Module.hello(any()), loop: [1,2,3,4]
+  ```elixir
+  allow Some.Module.hello(any()), seq: [1,2,3,4]
+  allow Some.Module.hello(any()), loop: [1,2,3,4]
 
-    or
+  # or
 
-    allow(Some.Module.hello(any())) |> seq([1,2,3,4])
-    allow(Some.Module.hello(any())) |> loop([1,2,3,4])
+  allow(Some.Module.hello(any())) |> seq([1,2,3,4])
+  allow(Some.Module.hello(any())) |> loop([1,2,3,4])
   ```
   seq will return the last value for every call after the last one is called
   loop will continue to loop around the list after the last one is called
@@ -71,24 +71,24 @@
   Any term passed in as an argument will be matched exactly.
   `Placebo.Matchers` provides several argument matchers to be used for more dynamic scenarios.
   If you need something custom you can pass a function to the is/1 matcher.
-  ```
-    allow Some.Module.hello(is(fn arg -> rem(arg,2) == 0 end)), return: "Even"
+  ```elixir
+  allow Some.Module.hello(is(fn arg -> rem(arg,2) == 0 end)), return: "Even"
 
-    or
+  # or
 
-    allow(Some.Module.hello(is(fn arg -> rem(arg,2) == 0 end))) |> return("Even")
+  allow(Some.Module.hello(is(fn arg -> rem(arg,2) == 0 end))) |> return("Even")
   ```
 
   all mocks created by Placebo are automaticaly created with :merge_expects option.
   So multiple allow statements can be made for the same function and will match in the order defined.
-  ```
-    allow Some.Module.hello(is(fn arg -> rem(arg,2) == 0 end))), return: "Even"
-    allow Some.Module.hello(any()), return: "Odd"
+  ```elixir
+  allow Some.Module.hello(is(fn arg -> rem(arg,2) == 0 end))), return: "Even"
+  allow Some.Module.hello(any()), return: "Odd"
 
-    or
+  # or
 
-    allow(Some.Module.hello(is(fn arg -> rem(arg,2) == 0 end)))) |> return("Even")
-    allow(Some.Module.hello(any())) |> return("Odd")
+  allow(Some.Module.hello(is(fn arg -> rem(arg,2) == 0 end)))) |> return("Even")
+  allow(Some.Module.hello(any())) |> return("Odd")
   ```
 
   # Verification
@@ -96,19 +96,19 @@
   Verification is done with assert_called and refute_called.
   All argument matchers also work in the verification step.
 
-  ```
-    assert_called Some.Module.hello("world")
-    assert_called Some.Module.hello("world"), once()
-    assert_called Some.Module.hello("world"), times(2)
+  ```elixir
+  assert_called Some.Module.hello("world")
+  assert_called Some.Module.hello("world"), once()
+  assert_called Some.Module.hello("world"), times(2)
   ```
 
   if you use expect instead of allow for any scenario. The interaction will automatically be verified at the end of the test.
-  ```
-    expect Some.Module.hello("world"), return: "some value"
+  ```elixir
+  expect Some.Module.hello("world"), return: "some value"
 
-    or
+  # or
 
-    expect(Some.Module.hello("world")) |> return("some value")
+  expect(Some.Module.hello("world")) |> return("some value")
   ```
 
   Failed verifications will automatically print out all recorded interactions with the mocked module.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Placebo
+# Placebo
 
 Placebo is a mocking library based on [meck](http://eproxus.github.io/meck/).
 It is inspired by [RSpec](http://rspec.info/) and [Mock](https://github.com/jjh42/mock).
@@ -42,8 +42,8 @@ allow(Some.Module.hello(any())) |> exec(fn arg -> String.upcase(arg) end)
 If you pass no arguments in the allow section the arguments to the anonymous function will be used for matching.
 ```elixir
 allow Some.Module.hello, exec: fn 1 -> "One"
-                                    2 -> "Two"
-                                    _ -> "Everything else" end
+                                  2 -> "Two"
+                                  _ -> "Everything else" end
 
 # or
 
@@ -65,7 +65,7 @@ allow(Some.Module.hello(any())) |> loop([1,2,3,4])
 seq will return the last value for every call after the last one is called
 loop will continue to loop around the list after the last one is called
 
-# Argument Matching
+## Argument Matching
 
 Any term passed in as an argument will be matched exactly.
 `Placebo.Matchers` provides several argument matchers to be used for more dynamic scenarios.
@@ -90,7 +90,7 @@ allow(Some.Module.hello(is(fn arg -> rem(arg,2) == 0 end)))) |> return("Even")
 allow(Some.Module.hello(any())) |> return("Odd")
 ```
 
-# Verification
+## Verification
 
 Verification is done with assert_called and refute_called.
 All argument matchers also work in the verification step.

--- a/README.md
+++ b/README.md
@@ -1,120 +1,116 @@
-  #Placebo
+#Placebo
 
-  Placebo is a mocking library based on [meck](http://eproxus.github.io/meck/).
-  It is inspired by [RSpec](http://rspec.info/) and [Mock](https://github.com/jjh42/mock).
-  All the functionality covered below is provided by meck.
-  Placebo is just a pretty wrapper around the features of meck.
+Placebo is a mocking library based on [meck](http://eproxus.github.io/meck/).
+It is inspired by [RSpec](http://rspec.info/) and [Mock](https://github.com/jjh42/mock).
+All the functionality covered below is provided by meck.
+Placebo is just a pretty wrapper around the features of meck.
 
-  To enable just use Placebo in your ExUnit tests
-  ```elixir
-  defmodule SomeTests do
-    use ExUnit.Case
-    use Placebo
+To enable just use Placebo in your ExUnit tests
+```elixir
+defmodule SomeTests do
+  use ExUnit.Case
+  use Placebo
 
-    ## some awesome tests
+  ## some awesome tests
 
-  end
-  ```
+end
+```
 
+## Stubbing
 
-  ## Stubbing
+```elixir
+allow Some.Module.hello("world"), return: "some value"
 
-  ```elixir
-  allow Some.Module.hello("world"), return: "some value"
+# or
 
-  # or
+allow(Some.Module.hello("world")) |> return("some value")
+```
+This will mock the module "Some.Module" and stub out the hello function with an argument of "world" to return "some value" when called.
+Any Elixir term can be returned using this syntax.
 
-  allow(Some.Module.hello("world")) |> return("some value")
-  ```
-  This will mock the module "Some.Module" and stub out the hello function with an argument of "world" to return "some value" when called.
-  Any Elixir term can be returned using this syntax.
+If you want more dyanmic behavior you can have a function executed when the mock is called.
+```elixir
+allow Some.Module.hello(any()), exec: &String.upcase/1
+allow Some.Module.hello(any()), exec: fn arg -> String.upcase(arg) end
 
-  If you want more dyanmic behavior you can have a function executed when the mock is called.
-  ```elixir
-  allow Some.Module.hello(any()), exec: &String.upcase/1
-  allow Some.Module.hello(any()), exec: fn arg -> String.upcase(arg) end
+# or
 
-  # or
+allow(Some.Module.hello(any())) |> exec(&String.upcase/1)
+allow(Some.Module.hello(any())) |> exec(fn arg -> String.upcase(arg) end)
+```
 
-  allow(Some.Module.hello(any())) |> exec(&String.upcase/1)
-  allow(Some.Module.hello(any())) |> exec(fn arg -> String.upcase(arg) end)
-  ```
+If you pass no arguments in the allow section the arguments to the anonymous function will be used for matching.
+```elixir
+allow Some.Module.hello, exec: fn 1 -> "One"
+                                    2 -> "Two"
+                                    _ -> "Everything else" end
 
-  If you pass no arguments in the allow section the arguments to the anonymous function will be used for matching.
-  ```elixir
-  allow Some.Module.hello, exec: fn 1 -> "One"
-                                      2 -> "Two"
-                                      _ -> "Everything else" end
+# or
 
-  # or
+allow(Some.Module.hello) |> exec(fn 1 -> "One"
+                                    2 -> "Two"
+                                    _ -> "Everything else" end)
+```
 
-  allow(Some.Module.hello) |> exec(fn 1 -> "One"
-                                      2 -> "Two"
-                                      _ -> "Everything else" end)
-  ```
+To return different values on subsequent calls use seq or loop
+```elixir
+allow Some.Module.hello(any()), seq: [1,2,3,4]
+allow Some.Module.hello(any()), loop: [1,2,3,4]
 
-  To return different values on subsequent calls use seq or loop
-  ```elixir
-  allow Some.Module.hello(any()), seq: [1,2,3,4]
-  allow Some.Module.hello(any()), loop: [1,2,3,4]
+# or
 
-  # or
+allow(Some.Module.hello(any())) |> seq([1,2,3,4])
+allow(Some.Module.hello(any())) |> loop([1,2,3,4])
+```
+seq will return the last value for every call after the last one is called
+loop will continue to loop around the list after the last one is called
 
-  allow(Some.Module.hello(any())) |> seq([1,2,3,4])
-  allow(Some.Module.hello(any())) |> loop([1,2,3,4])
-  ```
-  seq will return the last value for every call after the last one is called
-  loop will continue to loop around the list after the last one is called
+# Argument Matching
 
-  # Argument Matching
+Any term passed in as an argument will be matched exactly.
+`Placebo.Matchers` provides several argument matchers to be used for more dynamic scenarios.
+If you need something custom you can pass a function to the is/1 matcher.
+```elixir
+allow Some.Module.hello(is(fn arg -> rem(arg,2) == 0 end)), return: "Even"
 
-  Any term passed in as an argument will be matched exactly.
-  `Placebo.Matchers` provides several argument matchers to be used for more dynamic scenarios.
-  If you need something custom you can pass a function to the is/1 matcher.
-  ```elixir
-  allow Some.Module.hello(is(fn arg -> rem(arg,2) == 0 end)), return: "Even"
+# or
 
-  # or
+allow(Some.Module.hello(is(fn arg -> rem(arg,2) == 0 end))) |> return("Even")
+```
 
-  allow(Some.Module.hello(is(fn arg -> rem(arg,2) == 0 end))) |> return("Even")
-  ```
+all mocks created by Placebo are automaticaly created with :merge_expects option.
+So multiple allow statements can be made for the same function and will match in the order defined.
+```elixir
+allow Some.Module.hello(is(fn arg -> rem(arg,2) == 0 end))), return: "Even"
+allow Some.Module.hello(any()), return: "Odd"
 
-  all mocks created by Placebo are automaticaly created with :merge_expects option.
-  So multiple allow statements can be made for the same function and will match in the order defined.
-  ```elixir
-  allow Some.Module.hello(is(fn arg -> rem(arg,2) == 0 end))), return: "Even"
-  allow Some.Module.hello(any()), return: "Odd"
+# or
 
-  # or
+allow(Some.Module.hello(is(fn arg -> rem(arg,2) == 0 end)))) |> return("Even")
+allow(Some.Module.hello(any())) |> return("Odd")
+```
 
-  allow(Some.Module.hello(is(fn arg -> rem(arg,2) == 0 end)))) |> return("Even")
-  allow(Some.Module.hello(any())) |> return("Odd")
-  ```
+# Verification
 
-  # Verification
+Verification is done with assert_called and refute_called.
+All argument matchers also work in the verification step.
 
-  Verification is done with assert_called and refute_called.
-  All argument matchers also work in the verification step.
+```elixir
+assert_called Some.Module.hello("world")
+assert_called Some.Module.hello("world"), once()
+assert_called Some.Module.hello("world"), times(2)
+```
 
-  ```elixir
-  assert_called Some.Module.hello("world")
-  assert_called Some.Module.hello("world"), once()
-  assert_called Some.Module.hello("world"), times(2)
-  ```
+if you use expect instead of allow for any scenario. The interaction will automatically be verified at the end of the test.
+```elixir
+expect Some.Module.hello("world"), return: "some value"
 
-  if you use expect instead of allow for any scenario. The interaction will automatically be verified at the end of the test.
-  ```elixir
-  expect Some.Module.hello("world"), return: "some value"
+# or
 
-  # or
+expect(Some.Module.hello("world")) |> return("some value")
+```
 
-  expect(Some.Module.hello("world")) |> return("some value")
-  ```
-
-  Failed verifications will automatically print out all recorded interactions with the mocked module.
-
-
-
+Failed verifications will automatically print out all recorded interactions with the mocked module.
 
 ## Installation
 


### PR DESCRIPTION
- Fix code blocks to use elixir syntax highlighting
- Fix some whitespace issues
  - Remove 2 space margin throughout most of the README
  - Delete some extra empty lines
- Make markdown header use more consistent (all but `# Placebo` use `##` now)