### PR TITLE
Add Placebo.unstub

### DIFF
--- a/lib/placebo.ex
+++ b/lib/placebo.ex
@@ -137,8 +137,6 @@ defmodule Placebo do
             end)
           after
             Placebo.Server.clear()
-            Map.keys(mocks)
-            |> Enum.each(&:meck.unload/1)
           end
 
         end)
@@ -226,6 +224,8 @@ defmodule Placebo do
       false -> [:no_link, :merge_expects | opts]
     end
   end
+
+  defdelegate unstub, to: Placebo.Server, as: :clear
 
   def set_expectation(%Placebo.Mock{} = mock, {:return, value}) do
     Placebo.Actions.return(mock, value)

--- a/lib/placebo/server.ex
+++ b/lib/placebo/server.ex
@@ -33,6 +33,8 @@ defmodule Placebo.Server do
   end
 
   def handle_cast(:clear, _state) do
+    :meck.unload()
+
     Map.new()
     |> noreply()
   end

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,8 @@ defmodule Placebo.MixProject do
     [
       {:meck, "~> 0.8.9"},
       {:mix_test_watch, "~> 0.6.0", only: :dev, runtime: false},
-      {:ex_doc, "~> 0.16", only: :dev, runtime: false}
+      {:ex_doc, "~> 0.16", only: :dev, runtime: false},
+      {:stream_data, "~> 0.4", only: [:dev, :test]}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -6,4 +6,5 @@
   "hamcrest": {:hex, :hamcrest, "0.1.3", "6c79b5bbdde0bea1563e1ce4810ff89fdcec41ab1019dcaace146c4925506b65", [:make, :rebar3], [], "hexpm"},
   "meck": {:hex, :meck, "0.8.9", "64c5c0bd8bcca3a180b44196265c8ed7594e16bcc845d0698ec6b4e577f48188", [:rebar3], [], "hexpm"},
   "mix_test_watch": {:hex, :mix_test_watch, "0.6.0", "5e206ed04860555a455de2983937efd3ce79f42bd8536fc6b900cc286f5bb830", [:mix], [{:file_system, "~> 0.2.1 or ~> 0.3", [hex: :file_system, repo: "hexpm", optional: false]}], "hexpm"},
+  "stream_data": {:hex, :stream_data, "0.4.2", "fa86b78c88ec4eaa482c0891350fcc23f19a79059a687760ddcf8680aac2799b", [:mix], [], "hexpm"},
 }

--- a/test/placebo_test.exs
+++ b/test/placebo_test.exs
@@ -1,6 +1,7 @@
 defmodule PlaceboTest do
   use ExUnit.Case
   use Placebo
+  use ExUnitProperties
 
   test "Can stub out static value" do
     allow Placebo.Dummy.get(1), return: "Hello"
@@ -144,6 +145,28 @@ defmodule PlaceboTest do
     expect Placebo.Dummy.get("a"), return: "Browns"
 
     assert Placebo.Dummy.get("a") == "Browns"
+  end
+
+  describe "property-based testing" do
+    property "is possible with allow" do
+      check all dummy_in <- string(:alphanumeric),
+                dummy_out <- string(:alphanumeric) do
+        allow Placebo.Dummy.get(any()), return: dummy_out
+        assert Placebo.Dummy.get(dummy_in) == dummy_out
+
+        Placebo.unstub()
+      end
+    end
+
+    property "is possible with expect" do
+      check all dummy_in <- string(:alphanumeric),
+                dummy_out <- string(:alphanumeric) do
+        expect Placebo.Dummy.get(dummy_in), return: dummy_out
+        assert Placebo.Dummy.get(dummy_in) == dummy_out
+
+        Placebo.unstub()
+      end
+    end
   end
 
 end


### PR DESCRIPTION
Property-based testing with `stream_data` wasn't working properly. The state of stubs from previous iterations were being remembered and used, causing the assertions to fail. This PR fixes that by requiring property-based tests to `unstub` before the next iteration.

- Unload :meck with `Placebo.Server.clear`
- Add `Placebo.unstub` which delegates to `Placebo.Server.clear`
- Pull in `stream_data` for property-based testing