### PR TITLE
Formatter tweaks

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,9 @@
 # Used by "mix format"
 [
-  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  locals_without_parens: [allow: :*, expect: :*, matcher: :*],
+  line_length: 120,
+  export: [
+    locals_without_parens: [allow: :*, expect: :*]
+  ]
 ]

--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ defmodule SomeTests do
 end
 ```
 
+To ignore parentheses around mocks when running `mix format`, import your `:placebo` dependency in `.formatter.exs`:
+```elixir
+[
+  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  import_deps: [:placebo]
+]
+```
+
 ## Stubbing
 
 ```elixir

--- a/lib/placebo.ex
+++ b/lib/placebo.ex
@@ -1,5 +1,4 @@
 defmodule Placebo do
-
   @moduledoc """
   Placebo is a mocking library based on [meck](http://eproxus.github.io/meck/).
   It is inspired by [RSpec](http://rspec.info/) and [Mock](https://github.com/jjh42/mock).
@@ -125,7 +124,6 @@ defmodule Placebo do
 
       setup do
         on_exit(fn ->
-
           mocks = Placebo.Server.get()
 
           try do
@@ -133,12 +131,15 @@ defmodule Placebo do
             |> List.flatten()
             |> Enum.each(fn expectation ->
               assert :meck.called(expectation.module, expectation.function, expectation.args),
-                      Placebo.Helpers.failure_message(expectation.module, expectation.function, expectation.args)
+                     Placebo.Helpers.failure_message(
+                       expectation.module,
+                       expectation.function,
+                       expectation.args
+                     )
             end)
           after
             Placebo.Server.clear()
           end
-
         end)
 
         :ok
@@ -169,11 +170,17 @@ defmodule Placebo do
   end
 
   defmacro expect({{:., _, [module, f]}, _, args}, opts \\ []) do
-    record_expectation(module,f, args, opts, :expect)
+    record_expectation(module, f, args, opts, :expect)
   end
 
   defp record_expectation(module, function, args, opts, action) do
-    quote bind_quoted: [module: module, function: function, args: args, opts: opts, action: action] do
+    quote bind_quoted: [
+            module: module,
+            function: function,
+            args: args,
+            opts: opts,
+            action: action
+          ] do
       mock = %Placebo.Mock{
         module: module,
         function: function,
@@ -191,7 +198,7 @@ defmodule Placebo do
   defmacro assert_called({{:., _, [module, f]}, _, args}, validator \\ :any) do
     quote bind_quoted: [module: module, f: f, args: args, validator: validator] do
       Placebo.Helpers.called?(module, f, args, validator)
-      |> assert(Placebo.Helpers.failure_message(module,f,args))
+      |> assert(Placebo.Helpers.failure_message(module, f, args))
     end
   end
 
@@ -210,7 +217,7 @@ defmodule Placebo do
   defmacro refute_called({{:., _, [module, f]}, _, args}, validator \\ :any) do
     quote bind_quoted: [module: module, f: f, args: args, validator: validator] do
       Placebo.Helpers.called?(module, f, args, validator)
-      |> refute(Placebo.Helpers.failure_message(module,f,args))
+      |> refute(Placebo.Helpers.failure_message(module, f, args))
     end
   end
 
@@ -218,6 +225,7 @@ defmodule Placebo do
     if not Placebo.Server.is_mock?(mock.module) do
       :meck.new(mock.module, set_opts(mock.opts))
     end
+
     Placebo.Server.add_expectation(mock)
   end
 
@@ -233,15 +241,18 @@ defmodule Placebo do
   def set_expectation(%Placebo.Mock{} = mock, {:return, value}) do
     Placebo.Actions.return(mock, value)
   end
+
   def set_expectation(%Placebo.Mock{} = mock, {:exec, function}) do
     Placebo.Actions.exec(mock, function)
   end
+
   def set_expectation(%Placebo.Mock{} = mock, {:seq, list}) do
     Placebo.Actions.seq(mock, list)
   end
+
   def set_expectation(%Placebo.Mock{} = mock, {:loop, list}) do
     Placebo.Actions.loop(mock, list)
   end
-  def set_expectation(_mock, _keyword), do: nil
 
+  def set_expectation(_mock, _keyword), do: nil
 end

--- a/lib/placebo/actions.ex
+++ b/lib/placebo/actions.ex
@@ -1,5 +1,4 @@
 defmodule Placebo.Actions do
-
   def return(%Placebo.Mock{} = mock, value) do
     :meck.expect(mock.module, mock.function, mock.args, :meck.val(value))
   end
@@ -18,5 +17,4 @@ defmodule Placebo.Actions do
   def loop(%Placebo.Mock{} = mock, list) do
     :meck.expect(mock.module, mock.function, mock.args, :meck.loop(list))
   end
-
 end

--- a/lib/placebo/application.ex
+++ b/lib/placebo/application.ex
@@ -8,5 +8,4 @@ defmodule Placebo.Application do
 
     Supervisor.start_link(children, name: Placebo.Supervisor, strategy: :one_for_one)
   end
-
 end

--- a/lib/placebo/helpers.ex
+++ b/lib/placebo/helpers.ex
@@ -1,5 +1,4 @@
 defmodule Placebo.Helpers do
-
   def failure_message(module, function, args) do
     "Mock Verification Failed: #{output(module, function, args)}\nActual calls to Mock:\n#{format_history(module)}"
   end
@@ -10,11 +9,11 @@ defmodule Placebo.Helpers do
   end
 
   def format_history(module) do
-      :meck.history(module)
-      |> Enum.map(fn {_pid, {m, f, a}, _ret} ->
-        "\t#{m}.#{to_string(f)}(#{inspect(a)})"
-      end)
-      |> Enum.join("\n")
+    :meck.history(module)
+    |> Enum.map(fn {_pid, {m, f, a}, _ret} ->
+      "\t#{m}.#{to_string(f)}(#{inspect(a)})"
+    end)
+    |> Enum.join("\n")
   end
 
   def called?(module, function, args, validator) do
@@ -23,5 +22,4 @@ defmodule Placebo.Helpers do
       _ -> :meck.called(module, function, args)
     end
   end
-
 end

--- a/lib/placebo/macros.ex
+++ b/lib/placebo/macros.ex
@@ -1,5 +1,4 @@
 defmodule Placebo.Macros do
-
   defmacro matcher(name, do: block) do
     if references_input_variable?(block) do
       quote do
@@ -17,10 +16,11 @@ defmodule Placebo.Macros do
   end
 
   defp references_input_variable?(block) do
-    {_, result} = Macro.prewalk(block, false, fn exp, so_far ->
-      { exp, match?({:input,_,_}, exp) || so_far }
-    end)
+    {_, result} =
+      Macro.prewalk(block, false, fn exp, so_far ->
+        {exp, match?({:input, _, _}, exp) || so_far}
+      end)
+
     result
   end
-
 end

--- a/lib/placebo/matchers.ex
+++ b/lib/placebo/matchers.ex
@@ -27,5 +27,4 @@ defmodule Placebo.Matchers do
   def is(function) when is_function(function) do
     :meck.is(function)
   end
-
 end

--- a/lib/placebo/server.ex
+++ b/lib/placebo/server.ex
@@ -46,13 +46,13 @@ defmodule Placebo.Server do
 
   defp determine_value(state, mock) do
     current_value = Map.get(state, mock.module, [])
+
     case mock.action do
-      :expect -> [ %Placebo.Expectation{module: mock.module, function: mock.function, args: mock.args} | current_value ]
+      :expect -> [%Placebo.Expectation{module: mock.module, function: mock.function, args: mock.args} | current_value]
       _ -> current_value
     end
   end
 
   defp noreply(new_state), do: {:noreply, new_state}
   defp reply(value, new_state), do: {:reply, value, new_state}
-
 end

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@ defmodule Placebo.MixProject do
       description: description(),
       package: package(),
       deps: deps(),
-      name: "Placebo",
+      name: "Placebo"
     ]
   end
 
@@ -43,5 +43,4 @@ defmodule Placebo.MixProject do
   defp description do
     "A mocking library for ExUnit inspired by RSpec and based on meck."
   end
-
 end

--- a/test/matchers_test.exs
+++ b/test/matchers_test.exs
@@ -50,5 +50,4 @@ defmodule Placebo.MatchersTest do
     assert Regex.regex?(["a", "list"]) == :TERM
     assert Regex.regex?(%{map: "value"}) == :TERM
   end
-
 end

--- a/test/placebo_test.exs
+++ b/test/placebo_test.exs
@@ -38,8 +38,11 @@ defmodule PlaceboTest do
   end
 
   test "When no matcher given to mock with exec call, function args are matchers" do
-    allow Regex.regex?, exec: fn "one" -> 1
-                                  "two" -> 2 end
+    allow Regex.regex?(),
+      exec: fn
+        "one" -> 1
+        "two" -> 2
+      end
 
     assert Regex.regex?("one") == 1
     assert Regex.regex?("two") == 2
@@ -194,5 +197,4 @@ defmodule PlaceboTest do
       end
     end
   end
-
 end


### PR DESCRIPTION
- Ignore parens on `allow`, `expect`, and `matcher` in this project
- Bump line length threshold to 120 characters
- Export `allow` and `expect` for downstream projects
- Update README to explain setting up downstream project formatters
- Run formatter on this project