### PR TITLE
Fix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ by adding `placebo` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:placebo, "~> 1.2", only: :test}
+    {:placebo, "~> 1.2", only: [:dev, :test]}
   ]
 end
 ```


### PR DESCRIPTION
To pull in formatter configuration, users must pull `placebo` into the dev ENV
too. Update README to reflect that.